### PR TITLE
[Hacktoberfest] add standby signal

### DIFF
--- a/scripts/pg2/restore.sh
+++ b/scripts/pg2/restore.sh
@@ -5,5 +5,5 @@ cd "$(dirname "$0")/../../"
 
 docker-compose stop postgres2
 rm -rf volumes/postgres2/
-docker-compose run --rm postgres2 sh -c '/wal-g backup-fetch $PGDATA LATEST; touch $PGDATA/recovery.signal'
+docker-compose run --rm postgres2 sh -c '/wal-g backup-fetch $PGDATA LATEST; touch $PGDATA/recovery.signal; touch $PGDATA/standby.signal'
 docker-compose up -d postgres2


### PR DESCRIPTION


Hello, 

I think using `standby.signal` make example easy to understand as by default uploaded `wal`s from postgres1 backup are going to be recovered in postgres2

From Postgres doc

```
27.2.2. Standby Server Operation
A server enters standby mode if a standby.signal file exists in the data directory when the server is started.

In standby mode, the server continuously applies WAL received from the primary server.
```
